### PR TITLE
Doc updates and new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-An attempt at a responsive jquery lightbox plugin - in development.
+A responsive jQuery lightbox, that supports images, galleries, inline content, iframes, ajax and more.

--- a/index.html
+++ b/index.html
@@ -66,11 +66,11 @@
                 $(".rbox-video").rbox();
 
                 $(".rbox-not-close").rbox({
-                    closeonoverlay: false
+                    'closeonoverlay': false
                 })
 
                 $(".rbox-no-close-button").rbox({
-                    closebtn: false
+                    'closebtn': false
                 })
 
             });

--- a/index.html
+++ b/index.html
@@ -282,6 +282,7 @@
 
             <div id="testElement" style="display:none;">
                 <div class="content">Some content for a lovely lightbox!</div>
+                <div class="rbox-custom-close">Close</div>
             </div>        
         </main>
     </body>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,10 @@
                     closeonoverlay: false
                 })
 
+                $(".rbox-no-close-button").rbox({
+                    closebtn: false
+                })
+
             });
         </script>
     </head>
@@ -259,6 +263,7 @@
                 <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/ndKRjmA6WNA">iframe</span><br />
                 <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span><br>
                 <span class="rbox-not-close" data-rbox-image="test.jpg">Prevent closing the lightbox on clicking the overlay</span><br>
+                <span class="rbox-no-close-button" data-rbox-image="test.jpg">Hide Close icon</span>
             </div>
 
             <div id="testElement" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -63,6 +63,10 @@
                     'type': 'iframe'
                 });
                                 
+                $('.rbox-ajax').rbox({
+                    'type': 'ajax'
+                });
+
                 $(".rbox-video").rbox();
 
                 $(".rbox-not-close").rbox({
@@ -73,6 +77,9 @@
                     'closebtn': false
                 })
 
+                $(".rbox-custom-bg").rbox({
+                    'bgcustom' : 'rgba(255,255,255,0.8)'
+                })
             });
         </script>
     </head>
@@ -219,6 +226,12 @@
                 <td>true</td>
                 <td>close the lightbox on clicking the overlay</td>
             </tr>
+            <tr>
+                <td>bgcustom</td>
+                <td>string</td>
+                <td>rgba(0, 0, 0, 0.8)</td>
+                <td>customize the background overlay for each instance of the rbox, if you like. use rgba for transparent backgrounds.</td>
+            </tr>
         </table>
                         'namespace': namespace,
                         'loading': 'Loading...',
@@ -258,12 +271,13 @@
                 <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Another caption">Image Gallery</span><br>
                 <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="Caption are fun">Image Gallery</span><br>
                 <span class="rbox-html" data-rbox-type="html" data-rbox-series="x" data-rbox-html="Add your <strong>HTML</strong> here">HTML type</span><br />
-                <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
+                <span class="rbox-ajax" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
                 <span class="rbox-inline" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
                 <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/ndKRjmA6WNA">iframe</span><br />
                 <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span><br>
                 <span class="rbox-not-close" data-rbox-image="test.jpg">Prevent closing the lightbox on clicking the overlay</span><br>
-                <span class="rbox-no-close-button" data-rbox-image="test.jpg">Hide Close icon</span>
+                <span class="rbox-no-close-button" data-rbox-image="test.jpg">Hide Close icon</span><br>
+                <span class="rbox-custom-bg" data-rbox-image="test.jpg">Custom background overlay</span>
             </div>
 
             <div id="testElement" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -38,6 +38,12 @@
             .center {
                 text-align: center;
             }
+
+            .rbox-close-class {
+                color: white;
+                border: 1px solid;
+                padding: 5px;
+            }
         </style>
     
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
@@ -48,7 +54,8 @@
 
                 $('.rbox-gal').rbox({
                     'type': 'image',
-                    'series': 'image_gallery'
+                    'series': 'image_gallery',
+                    'navmarkup': [, "<img src='http://placehold.it/20x20'>",]
                 }); 
 
                 $('.rbox-inline').rbox({
@@ -76,6 +83,13 @@
                 $(".rbox-no-close-button").rbox({
                     'closebtn': false
                 })
+
+                // $('.rbox-close-markup').rbox({
+                // });
+
+                $('.rbox-close-class-custom').rbox({
+                    'closebtnclass': 'rbox-close-class'
+                });
 
                 $(".rbox-custom-bg").rbox({
                     'bgcustom' : 'rgba(255,255,255,0.8)'
@@ -277,12 +291,13 @@
                 <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span><br>
                 <span class="rbox-not-close" data-rbox-image="test.jpg">Prevent closing the lightbox on clicking the overlay</span><br>
                 <span class="rbox-no-close-button" data-rbox-image="test.jpg">Hide Close icon</span><br>
+                <!-- <span class="rbox-close-markup" data-rbox-image="test.jpg">Custom close markup</span><br> -->
+                <span class="rbox-close-class-custom" data-rbox-image="test.jpg">Custom close class</span><br>
                 <span class="rbox-custom-bg" data-rbox-image="test.jpg">Custom background overlay</span>
             </div>
 
             <div id="testElement" style="display:none;">
                 <div class="content">Some content for a lovely lightbox!</div>
-                <div class="rbox-custom-close">Close</div>
             </div>        
         </main>
     </body>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
         <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="jquery-rbox.css" />
         <style>
-            /* These styles don't need to be included for the lightbox to work - simply present for the demo page */
             body {
                 font-family: 'Open Sans', sans-serif;
                 font-size: 100%;

--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@
             <span class="rbox-html" data-rbox-type="html" data-rbox-series="x" data-rbox-html="Add your <strong>HTML</strong> here">HTML type</span><br />
             <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
             <span class="rbox-inline" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
-            <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="http://youtu.be/LZxKUDtPMDg">iframe</span><br />
+            <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/ndKRjmA6WNA">iframe</span><br />
             <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -38,18 +38,26 @@
         <script src="jquery-rbox.js"></script>
         <script>
             $(document).ready(function(){
-                $('.rbox_img').rbox();
+                $('.rbox-img').rbox();
 
-                $('.rbox_img_gal').rbox({
+                $('.rbox-gal').rbox({
                     'type': 'image',
                     'series': 'image_gallery'
                 }); 
 
-                $('.rbox_inline').rbox({
+                $('.rbox-inline').rbox({
                     'type': 'inline'
                 });
                 
-                $(".rbox_video").rbox();
+                $('.rbox-html').rbox({
+                    'type': 'html'
+                });
+                           
+                $('.rbox-iframe').rbox({
+                    'type': 'iframe'
+                });
+                                
+                $(".rbox-video").rbox();
 
             });
         </script>
@@ -225,20 +233,20 @@
  -->
             <h4>Examples</h4>
  
-            <span class="rbox_img" data-rbox-image="test.jpg" data-rbox-caption="Add a caption">Single Image</span><br>
-            <span class="rbox_img_gal" data-rbox-image="test2.jpg" data-rbox-caption="Your captions can have  <strong>HTML</strong>">Image Gallery</span><br>
-            <span class="rbox_img_gal" data-rbox-image="test.jpg" data-rbox-caption="foobar">Image Gallery</span><br>
-            <span class="rbox_img_gal" data-rbox-image="test2.jpg" data-rbox-caption="foobar">Image Gallery</span><br>
-            <span class="rbox_img_gal" data-rbox-image="test.jpg" data-rbox-caption="foobar">Image Gallery</span><br>
-            <span class="foo" data-rbox-type="html" data-rbox-series="x" data-rbox-html="something random">HTML type</span><br />
+            <span class="rbox-img" data-rbox-image="test.jpg" data-rbox-caption="My caption">Single Image</span><br>
+            <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Your captions can have  <strong>HTML</strong>">Image Gallery</span><br>
+            <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="A caption">Image Gallery</span><br>
+            <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Another caption">Image Gallery</span><br>
+            <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="Caption are fun">Image Gallery</span><br>
+            <span class="rbox-html" data-rbox-type="html" data-rbox-series="x" data-rbox-html="Add your <strong>HTML</strong> here">HTML type</span><br />
             <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
-            <span class="rbox_img" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
-            <span class="foo" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/6IpMHy-rqKo">iframe</span><br />
-            <span class="rbox_video" data-rbox-type="video" data-rbox-series="x" data-rbox-autoplay="true" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span>
+            <span class="rbox-inline" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
+            <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="http://youtu.be/LZxKUDtPMDg">iframe</span><br />
+            <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span>
         </div>
 
         <div id="testElement" style="display:none;">
-            <div class="content">Some content for a lovely lightbox! Captions are being appended to everything!!!! BUG</div>
+            <div class="content">Some content for a lovely lightbox!</div>
         </div>
     </body>
 

--- a/index.html
+++ b/index.html
@@ -8,9 +8,6 @@
             body {
                 font-family: 'Open Sans', sans-serif;
                 font-size: 100%;
-            }
-            
-            body {
                 margin: 0;
                 padding: 0;
             }
@@ -30,6 +27,16 @@
             td {
                 padding: 5px;
                 border: 1px solid #aaa;
+            }
+
+            .main {
+                max-width: 800px;
+                margin: 0 auto;
+            }
+
+            /* Helpers */
+            .center {
+                text-align: center;
             }
         </style>
     
@@ -63,190 +70,190 @@
     </head>
 
     <body>
-    <h1>jQuery Rbox Demo and Documentation</h1>
-    
-    <h5>To use:</h5>
-    <div><strong>Include jQuery and the rbox script: </strong></div>
-    <p>Include jQuery, followed by the jquery-rbox script in the head tag or just below the closing body tag.</p>
-    
-    <pre>
-        <code>
-            &lt;script src="http://code.jquery.com/jquery-1.11.0.min.js"&gt;&lt;/script&gt;
-            &lt;script src="jquery-rbox.js"&gt;&lt;/script&gt;
-        </code>
-    </pre>
-    
-    <div><strong>Include the stylesheet: </strong></div>
-    <p>Include the jquery-rbox.css stylesheet in the head tag</p>
-    
-    <pre>
-        <code>
-            &lt;link rel="stylesheet" href="jquery-rbox.css" /glt;            
-        </code>
-    </pre>
-    
-    <div><strong>Call rbox on an element:</strong></div>
-    <p><em>e.g. something with a class of foo</em></p>
-    <p>Do this below the rbox script tag</p>
-    
-    <pre>
-        <code>
-            $(document.ready(function() {
-                $('.foo').rbox();
-            });            
-        </code>
-    </pre>
-    
-    <h4>Features</h4>
-    <ul>
-        <li>Responsive across devices</li>
-        <li>Can be used with inline elements, single images and videos, image and video galleries, iframes and ajax.</li>
-        <li>Really lightweight, unminified is 12kb!</li>
-        <li></li>
-        <li></li>
-        <li></li>
-    </ul>
-    
-    <h4>Options</h4>
-    <table>
-        <thead>
-            <td>Name</td>
-            <td>Type</td>
-            <td>Default</td>
-            <td>Description</td>
-        </thead>
-        <tr>
-            <td>series</td>
-            <td>string</td>
-            <td></td>
-            <td>series this lightbox is a part of</td>
-        </tr>
-        <tr>
-            <td>type</td>
-            <td>string</td>
-            <td></td>
-            <td>image, video, inline, html, iframe or ajax</td>
-        </tr>
-        <tr>
-            <td>image</td>
-            <td>string</td>
-            <td></td>
-            <td>path to image, for type image</td>
-        </tr>
-        <tr>
-            <td>video</td>
-            <td>string</td>
-            <td></td>
-            <td>path to video file, for type video</td>
-        </tr>
-        <tr>
-            <td>iframe</td>
-            <td>string</td>
-            <td></td>
-            <td>path to iframe, for type iframe</td>
-        </tr>
-        <tr>
-            <td>ajax</td>
-            <td>string</td>
-            <td></td>
-            <td>URL to fetch ajax content from</td>
-        </tr>
-        <tr>
-            <td>html</td>
-            <td>string</td>
-            <td></td>
-            <td>add some html here</td>
-        </tr>
-        <tr>
-            <td>inline</td>
-            <td>string</td>
-            <td></td>
-            <td>selector for element on page whose innerHTML is the content</td>
-        </tr>
-        <tr>
-            <td>caption</td>
-            <td>string</td>
-            <td></td>
-            <td>optional caption</td>
-        </tr>
-        <tr>
-            <td>width</td>
-            <td>number</td>
-            <td>0</td>
-            <td>defined in pixels. Default width of 0 implies auto</td>
-        </tr>
-        <tr>
-            <td>height</td>
-            <td>number</td>
-            <td>0</td>
-            <td>defined in pixels. Default height of 0 implies auto</td>
-        </tr>
-        <tr>
-            <td>videoposter</td>
-            <td>string</td>
-            <td></td>
-            <td>poster image path for videos</td>
-        </tr>
-        <tr>
-            <td>autoplay</td>
-            <td>boolean</td>
-            <td>false</td>
-            <td>if type==video, if video should autoplay</td>
-        </tr>
-        <tr>
-            <td>fitvid</td>
-            <td>boolean</td>
-            <td>false</td>
-            <td>whether to use the fitvids.js plugin (needs to be included). This ensures responsive videos inside iframes. Not required for HTML5 video</td>
-        </tr>
-    </table>
-                    'namespace': namespace,
-                    'loading': 'Loading...',
-                    'beforeopen': function(opts) { return opts; }, //called before open
-                    'onopen': function() { $.noop(); }, //called onopen
-                    'onclose': function() { $.noop(); }, //called onclose
-                    'beforeclose': function() { $.noop(); }
+        <main class="main">
+        <h1 class="center">jQuery Rbox Demo &amp; Documentation</h1>
+        
+        <h2>Usage:</h2>
+        <div><strong>Include jQuery and the jQuery Rbox javascript: </strong></div>
+        
+<pre>
+    <code>
+        // Include either in the head or just above closing body tag
+        &lt;script src="http://code.jquery.com/jquery-1.11.0.min.js"&gt;&lt;/script&gt;
+        &lt;script src="jquery-rbox.js"&gt;&lt;/script&gt;
+    </code>
+</pre>
+        
+        <div><strong>Include the jquery-rbox.css stylesheet in the head tag: </strong></div>
 
-    <!--
-    <div class="rbox_overlay">
-        <div class="rbox_lightBoxBlock">
-            <div class="rbox_lightBox">
-                <div class="rbox_lightBoxContent">
-    
+<pre>
+    <code>
+        &lt;link rel="stylesheet" href="jquery-rbox.css" /glt;            
+    </code>
+</pre>
+        
+        <div><strong>Call rbox on an element:</strong></div>
+        <p><em>e.g. something with a class of foo</em></p>
+        
+<pre>
+    <code>
+        $(document.ready(function() {
+            $('.foo').rbox();
+        });            
+    </code>
+</pre>
+        
+        <h2>Features</h2>
+        <ul>
+            <li>Responsive across devices</li>
+            <li>Can be used with inline elements, single images and videos, image and video galleries, iframes and ajax.</li>
+            <li>Really lightweight, unminified JS file is 13kb!</li>
+            <li></li>
+            <li></li>
+            <li></li>
+        </ul>
+        
+        <h4>Options</h4>
+        <table>
+            <thead>
+                <td>Name</td>
+                <td>Type</td>
+                <td>Default</td>
+                <td>Description</td>
+            </thead>
+            <tr>
+                <td>series</td>
+                <td>string</td>
+                <td></td>
+                <td>series this lightbox is a part of</td>
+            </tr>
+            <tr>
+                <td>type</td>
+                <td>string</td>
+                <td></td>
+                <td>image, video, inline, html, iframe or ajax</td>
+            </tr>
+            <tr>
+                <td>image</td>
+                <td>string</td>
+                <td></td>
+                <td>path to image, for type image</td>
+            </tr>
+            <tr>
+                <td>video</td>
+                <td>string</td>
+                <td></td>
+                <td>path to video file, for type video</td>
+            </tr>
+            <tr>
+                <td>iframe</td>
+                <td>string</td>
+                <td></td>
+                <td>path to iframe, for type iframe</td>
+            </tr>
+            <tr>
+                <td>ajax</td>
+                <td>string</td>
+                <td></td>
+                <td>URL to fetch ajax content from</td>
+            </tr>
+            <tr>
+                <td>html</td>
+                <td>string</td>
+                <td></td>
+                <td>add some html here</td>
+            </tr>
+            <tr>
+                <td>inline</td>
+                <td>string</td>
+                <td></td>
+                <td>selector for element on page whose innerHTML is the content</td>
+            </tr>
+            <tr>
+                <td>caption</td>
+                <td>string</td>
+                <td></td>
+                <td>optional caption</td>
+            </tr>
+            <tr>
+                <td>width</td>
+                <td>number</td>
+                <td>0</td>
+                <td>defined in pixels. Default width of 0 implies auto</td>
+            </tr>
+            <tr>
+                <td>height</td>
+                <td>number</td>
+                <td>0</td>
+                <td>defined in pixels. Default height of 0 implies auto</td>
+            </tr>
+            <tr>
+                <td>videoposter</td>
+                <td>string</td>
+                <td></td>
+                <td>poster image path for videos</td>
+            </tr>
+            <tr>
+                <td>autoplay</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>if type==video, if video should autoplay</td>
+            </tr>
+            <tr>
+                <td>fitvid</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>whether to use the fitvids.js plugin (needs to be included). This ensures responsive videos inside iframes. Not required for HTML5 video</td>
+            </tr>
+        </table>
+                        'namespace': namespace,
+                        'loading': 'Loading...',
+                        'beforeopen': function(opts) { return opts; }, //called before open
+                        'onopen': function() { $.noop(); }, //called onopen
+                        'onclose': function() { $.noop(); }, //called onclose
+                        'beforeclose': function() { $.noop(); }
+
+        <!--
+        <div class="rbox_overlay">
+            <div class="rbox_lightBoxBlock">
+                <div class="rbox_lightBox">
+                    <div class="rbox_lightBoxContent">
+        
+                    </div>
+                    <a href="" class="closeLightBox">X</a>
+                    <a href="" class="nextLightBox">&#8594;</a>
+                    <a href="" class="prevLightBox">&#8592;</a>
                 </div>
-                <a href="" class="closeLightBox">X</a>
-                <a href="" class="nextLightBox">&#8594;</a>
-                <a href="" class="prevLightBox">&#8592;</a>
             </div>
         </div>
-    </div>
-    -->
+        -->
 
-        <div id="wrapper">
-<!--             <span class="foo" data-rbox-type="image" data-rbox-series="x" data-rbox-image="test.jpg">FOO</span><br>
-            <span class="foo" data-rbox-type="html" data-rbox-series="x" data-rbox-html="something random">faaaa</span><br />
-            <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
-            <span class="foo" data-rbox-type="element" data-rbox-series="x" data-rbox-element="#testElement">hidden element</span><br />
-            <span class="foo" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/6IpMHy-rqKo">iframe</span><br />
-            <span class="foo" data-rbox-type="video" data-rbox-series="x" data-rbox-autoplay="true" data-rbox-video="http://marlon.in/streaming/1-Zuska.mp4">Test Video</span>
- -->
-            <h4>Examples</h4>
- 
-            <span class="rbox-img" data-rbox-image="test.jpg" data-rbox-caption="My caption">Single Image</span><br>
-            <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Your captions can have  <strong>HTML</strong>">Image Gallery</span><br>
-            <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="A caption">Image Gallery</span><br>
-            <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Another caption">Image Gallery</span><br>
-            <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="Caption are fun">Image Gallery</span><br>
-            <span class="rbox-html" data-rbox-type="html" data-rbox-series="x" data-rbox-html="Add your <strong>HTML</strong> here">HTML type</span><br />
-            <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
-            <span class="rbox-inline" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
-            <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/ndKRjmA6WNA">iframe</span><br />
-            <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span>
-        </div>
+            <div id="wrapper">
+    <!--             <span class="foo" data-rbox-type="image" data-rbox-series="x" data-rbox-image="test.jpg">FOO</span><br>
+                <span class="foo" data-rbox-type="html" data-rbox-series="x" data-rbox-html="something random">faaaa</span><br />
+                <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
+                <span class="foo" data-rbox-type="element" data-rbox-series="x" data-rbox-element="#testElement">hidden element</span><br />
+                <span class="foo" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/6IpMHy-rqKo">iframe</span><br />
+                <span class="foo" data-rbox-type="video" data-rbox-series="x" data-rbox-autoplay="true" data-rbox-video="http://marlon.in/streaming/1-Zuska.mp4">Test Video</span>
+     -->
+                <h4>Examples</h4>
+     
+                <span class="rbox-img" data-rbox-image="test.jpg" data-rbox-caption="My caption">Single Image</span><br>
+                <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Your captions can have  <strong>HTML</strong>">Image Gallery</span><br>
+                <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="A caption">Image Gallery</span><br>
+                <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Another caption">Image Gallery</span><br>
+                <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="Caption are fun">Image Gallery</span><br>
+                <span class="rbox-html" data-rbox-type="html" data-rbox-series="x" data-rbox-html="Add your <strong>HTML</strong> here">HTML type</span><br />
+                <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
+                <span class="rbox-inline" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
+                <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/ndKRjmA6WNA">iframe</span><br />
+                <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span>
+            </div>
 
-        <div id="testElement" style="display:none;">
-            <div class="content">Some content for a lovely lightbox!</div>
-        </div>
+            <div id="testElement" style="display:none;">
+                <div class="content">Some content for a lovely lightbox!</div>
+            </div>        
+        </main>
     </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -304,16 +304,29 @@ $(document.ready(function() {
                 <h3>Examples</h3>
      
                 <h4>Image</h4>
-                <span class="rbox-img" data-rbox-image="test.jpg" data-rbox-caption="My caption">Single Image</span><br>
-
-                <h4>Series or Galleries</h4>
-                <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Your captions can have  <strong>HTML</strong>">Image Gallery</span><br>
-                <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="A caption">Image Gallery</span><br>
-                <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Another caption">Image Gallery</span><br>
-                <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="Caption are fun">Image Gallery</span><br>
+                <a href="" class="rbox-img" data-rbox-image="test.jpg"><img src="test.jpg" alt="Test Image" width="100"></a>
 <pre>
     <code class="code-block">
-// Option 1: As data attribute
+// Option 1: In Markup
+&lt;a href="" class="rbox-img" data-rbox-image="test.jpg"&gt;
+  &lt;img src="test.jpg" alt="Test Image" width="100"&gt;
+&lt;/a&gt;
+
+// Option 2: In JS
+$(".rbox-img").rbox({
+    'type': 'image'
+});
+    </code>
+</pre>
+
+                <h4>Series or Galleries</h4>
+                <a href="" class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Your captions can have  <strong>HTML</strong>"><img src="test2.jpg" alt="Test Image" width="100"></a>
+                <a href="" class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="A caption"><img src="test.jpg" alt="Test Image" width="100"></a>
+                <a href="" class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Another caption"><img src="test2.jpg" alt="Test Image" width="100"></a>
+                <a href="" class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="Caption are fun"><img src="test.jpg" alt="Test Image" width="100"></a>
+<pre>
+    <code class="code-block">
+// Option 1: In Markup
 &lt;span class="rbox-gal" data-rbox-image="a.jpg" data-rbox-series="gallery"&gt;
 Image Gallery
 &lt;/span&gt;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 <html>
     <head>
         <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css'>
-        <!-- <link rel="stylesheet" href="reset.css" /> -->
         <link rel="stylesheet" href="jquery-rbox.css" />
         <style>
             /* These styles don't need to be included for the lightbox to work - simply present for the demo page */
@@ -48,7 +47,9 @@
 
                 $('.rbox_inline').rbox({
                     'type': 'inline'
-                }); 
+                });
+                
+                $(".rbox_video").rbox();
 
             });
         </script>
@@ -233,7 +234,7 @@
             <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
             <span class="rbox_img" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
             <span class="foo" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/6IpMHy-rqKo">iframe</span><br />
-            <span class="foo" data-rbox-type="video" data-rbox-series="x" data-rbox-autoplay="true" data-rbox-video="http://marlon.in/streaming/1-Zuska.mp4">Test Video</span>
+            <span class="rbox_video" data-rbox-type="video" data-rbox-series="x" data-rbox-autoplay="true" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span>
         </div>
 
         <div id="testElement" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
                                 
                 $(".rbox-video").rbox();
 
+                $(".rbox-not-close").rbox({
+                    closeonoverlay: false
+                })
+
             });
         </script>
     </head>
@@ -205,6 +209,12 @@
                 <td>false</td>
                 <td>whether to use the fitvids.js plugin (needs to be included). This ensures responsive videos inside iframes. Not required for HTML5 video</td>
             </tr>
+            <tr>
+                <td>closeonoverlay</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>close the lightbox on clicking the overlay</td>
+            </tr>
         </table>
                         'namespace': namespace,
                         'loading': 'Loading...',
@@ -247,7 +257,8 @@
                 <span class="foo" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
                 <span class="rbox-inline" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
                 <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/ndKRjmA6WNA">iframe</span><br />
-                <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span>
+                <span class="rbox-video" data-rbox-type="video" data-rbox-series="x" data-rbox-video="http://marlon.in/media/files/boost_virat_for_reel.mp4">Test Video</span><br>
+                <span class="rbox-not-close" data-rbox-image="test.jpg">Prevent closing the lightbox on clicking the overlay</span><br>
             </div>
 
             <div id="testElement" style="display:none;">

--- a/index.html
+++ b/index.html
@@ -2,12 +2,13 @@
 
 <html>
     <head>
-        <link href='http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700' rel='stylesheet' type='text/css'>
+        <link href='http://fonts.googleapis.com/css?family=Lato:400italic,400,700|Anonymous+Pro' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" href="jquery-rbox.css" />
         <style>
             body {
-                font-family: 'Open Sans', sans-serif;
-                font-size: 100%;
+                font-family: 'Lato', sans-serif;
+                font-size: 17px;
+                line-height: 1.4;
                 margin: 0;
                 padding: 0;
             }
@@ -25,13 +26,32 @@
             }
             
             td {
-                padding: 5px;
-                border: 1px solid #aaa;
+                padding: 10px;
+                border: 1px solid #ccc;
+            }
+
+            code {
+                font-family: "Anonymous Pro", monospace;
+                background: #eee;
+            }
+
+            .code-block {
+                display: block;
+                padding: 0px 15px;
+                border-left: 4px solid seagreen;
             }
 
             .main {
                 max-width: 800px;
                 margin: 0 auto;
+            }
+
+            .table-options {
+                font-size: 90%;
+            }
+
+            .table-options tr td:nth-of-type(3) {
+                width: 120px;
             }
 
             /* Helpers */
@@ -102,35 +122,38 @@
         <main class="main">
         <h1 class="center">jQuery Rbox Demo &amp; Documentation</h1>
         
-        <h2>Usage:</h2>
-        <div><strong>Include jQuery and the jQuery Rbox javascript: </strong></div>
-        
+        <h2>Usage</h2>
+        <ol>
+            <li>
+                <p><strong>Include jQuery and the jquery-rbox.js file. </strong></p>
 <pre>
-    <code>
-        // Include either in the head or just above closing body tag
-        &lt;script src="http://code.jquery.com/jquery-1.11.0.min.js"&gt;&lt;/script&gt;
-        &lt;script src="jquery-rbox.js"&gt;&lt;/script&gt;
-    </code>
-</pre>
-        
-        <div><strong>Include the jquery-rbox.css stylesheet in the head tag: </strong></div>
+    <code class="code-block">
+// Include either in the head or just above closing body tag
 
-<pre>
-    <code>
-        &lt;link rel="stylesheet" href="jquery-rbox.css" /glt;            
+&lt;script src="http://code.jquery.com/jquery-1.11.3.min.js"&gt;&lt;/script&gt;
+&lt;script src="jquery-rbox.js"&gt;&lt;/script&gt;
     </code>
 </pre>
-        
-        <div><strong>Call rbox on an element:</strong></div>
-        <p><em>e.g. something with a class of foo</em></p>
-        
+            </li>
+            <li>
+                <p><strong>Include the jquery-rbox.css stylesheet in the head tag.</strong></p>
 <pre>
-    <code>
-        $(document.ready(function() {
-            $('.foo').rbox();
-        });            
+    <code class="code-block">
+&lt;link rel="stylesheet" href="jquery-rbox.css"&gt;            
     </code>
 </pre>
+            </li>
+            <li>
+                <p><strong>Initialize rbox.</strong></p>
+<pre>
+    <code class="code-block">
+$(document.ready(function() {
+    $('.foo').rbox();
+});            
+    </code>
+</pre>
+            </li>
+        </ol>         
         
         <h2>Features</h2>
         <ul>
@@ -143,7 +166,7 @@
         </ul>
         
         <h4>Options</h4>
-        <table>
+        <table class="table-options">
             <thead>
                 <td>Name</td>
                 <td>Type</td>
@@ -154,13 +177,14 @@
                 <td>series</td>
                 <td>string</td>
                 <td></td>
-                <td>series this lightbox is a part of</td>
+                <td>Series can be used for image galleries, etc.
+                </td>
             </tr>
             <tr>
                 <td>type</td>
                 <td>string</td>
                 <td></td>
-                <td>image, video, inline, html, iframe or ajax</td>
+                <td>Image, video, inline, html, iframe or ajax</td>
             </tr>
             <tr>
                 <td>image</td>
@@ -277,14 +301,34 @@
                 <span class="foo" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/6IpMHy-rqKo">iframe</span><br />
                 <span class="foo" data-rbox-type="video" data-rbox-series="x" data-rbox-autoplay="true" data-rbox-video="http://marlon.in/streaming/1-Zuska.mp4">Test Video</span>
      -->
-                <h4>Examples</h4>
+                <h3>Examples</h3>
      
+                <h4>Image</h4>
                 <span class="rbox-img" data-rbox-image="test.jpg" data-rbox-caption="My caption">Single Image</span><br>
+
+                <h4>Series or Galleries</h4>
                 <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Your captions can have  <strong>HTML</strong>">Image Gallery</span><br>
                 <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="A caption">Image Gallery</span><br>
                 <span class="rbox-gal" data-rbox-image="test2.jpg" data-rbox-caption="Another caption">Image Gallery</span><br>
                 <span class="rbox-gal" data-rbox-image="test.jpg" data-rbox-caption="Caption are fun">Image Gallery</span><br>
-                <span class="rbox-html" data-rbox-type="html" data-rbox-series="x" data-rbox-html="Add your <strong>HTML</strong> here">HTML type</span><br />
+<pre>
+    <code class="code-block">
+// Option 1: As data attribute
+&lt;span class="rbox-gal" data-rbox-image="a.jpg" data-rbox-series="gallery"&gt;
+Image Gallery
+&lt;/span&gt;
+&lt;span class="rbox-gal" data-rbox-image="b.jpg" data-rbox-series="gallery"&gt;
+Image Gallery
+&lt;/span&gt;
+
+// Option 2: In JS
+$(".rbox-gal").rbox({
+    'type': 'image',
+    'series': 'gallery'
+});
+    </code>
+</pre>
+             <span class="rbox-html" data-rbox-type="html" data-rbox-series="x" data-rbox-html="Add your <strong>HTML</strong> here">HTML type</span><br />
                 <span class="rbox-ajax" data-rbox-type="ajax" data-rbox-series="x" data-rbox-ajax="test.html">ajax link</span><br />
                 <span class="rbox-inline" data-rbox-type="inline" data-rbox-series="x" data-rbox-inline="#testElement">hidden element</span><br />
                 <span class="rbox-iframe" data-rbox-type="iframe" data-rbox-series="x" data-rbox-width="420" data-rbox-height="315" data-rbox-iframe="//www.youtube.com/embed/ndKRjmA6WNA">iframe</span><br />

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -63,6 +63,11 @@ img {
 
 .nextLightBox, .prevLightBox, .closeLightBox {
 	text-decoration: none;
+	padding: 10px;
+}
+
+/*.closeLightBox:after {
+	content: "\274c";
 }
 
 .nextLightBox:after {
@@ -71,20 +76,19 @@ img {
 
 .prevLightBox:after {
 	content: "\25c0";
-}
+}*/
 
 .closeLightBox {
 	position: absolute;
 	right: -14px;
 	top:-26px;
-	padding: 4px;
-	font-size: 220%;
+	font-size: 20px;
 }
 
 .nextLightBox, .prevLightBox {
 	position: absolute;
 	top: 44%;
-	font-size: 300%;
+	font-size: 20px;
 }
 
 .nextLightBox {

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -16,15 +16,15 @@ img {
 /* LIGHTBOX */
     
 .rbox_overlay {
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    left: 0;
-    top: 0;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  left: 0;
+  top: 0;
 	bottom: 0;
 	right: 0;
-    background: #000;
-    background: rgba(0,0,0,0.8);
+  background: #000;
+  background: rgba(0,0,0,0.8);
 	opacity: 0;
 	/* text-align: center; */
 	z-index: -1;

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -114,7 +114,6 @@ img {
 
 	-webkit-animation: rotate 500ms ease-in 0ms forwards;
 	animation: rotate 500ms ease-in 0ms forwards;
-
 }
 
 .rbox_caption {

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -1,4 +1,6 @@
 /* vertical centering via display flex causes issues on smaller screens on narrower displays require the animation on the box, not the contents
+ // Does rbox try to guess what type of element it is?
+
 */
 
 * {

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -9,15 +9,6 @@ require the animation on the box, not the contents
 	box-sizing: border-box; 
 }
 
-html, body  { 
-	height: 100%;
-	width: 100%;
-}
-
-body {
-	color: #222;
-}
-
 img {
     max-width: 100%;
     height: auto;

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -137,7 +137,7 @@ height: 90%;
 	max-width: 100%;
 }
 
-.rbox_inline {
+.rbox_inline, .rbox_html {
 	background: #fff;
 	padding: 20px;
 }
@@ -147,6 +147,10 @@ height: 90%;
 	-webkit-animation: rotate 500ms ease-in 0ms forwards;
 	animation: rotate 500ms ease-in 0ms forwards;
 
+}
+
+.rbox_caption {
+	color: #fff;
 }
 
 @-webkit-keyframes rotate {

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -11,10 +11,6 @@ html, body  {
 }
 
 body {
-	/* background-color: #fff;
-	font-family:sans-serif;
-	font-size: 16px;
-	line-height: 1.4; */
 	color: #222;
 }
 
@@ -22,34 +18,6 @@ img {
     max-width: 100%;
     height: auto;
 }
-
-/* COLUMNS */
-
-/*.col25 {
-	width: 25%;
-}
-
-.col33 {
-	width:33.33%;
-}
-
-.col50 {
-	width: 50%;
-}
-
-.col75 {
-	width:75%;
-}
-*/
-
-/* COLUMNS */
-
-/* GLOBAL STYLES */
-
-
-.clear { 
-	clear: both;
-} 
 
 /* LIGHTBOX */
     
@@ -78,9 +46,7 @@ img {
 }
 
 .rbox_lightBoxBlock {
-/*     width: 80%;
-height: 90%;
- */    margin: 0 auto;
+	margin: 0 auto;
     margin-top: 5%;
     margin-bottom: 5%;
     position: relative;

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -1,5 +1,4 @@
-/* vertical centering via display flex causes issues on smaller screens on narrower displays
-require the animation on the box, not the contents
+/* vertical centering via display flex causes issues on smaller screens on narrower displays require the animation on the box, not the contents
 */
 
 * {

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -1,5 +1,7 @@
 /* vertical centering via display flex causes issues on smaller screens on narrower displays require the animation on the box, not the contents
  // Does rbox try to guess what type of element it is?
+ // data attrs all broken
+ // custom close class needs to be deactivated
 
 */
 

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -79,7 +79,6 @@ img {
 	top:-26px;
 	padding: 4px;
 	font-size: 220%;
-	display: none;
 }
 
 .nextLightBox, .prevLightBox {

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -79,6 +79,7 @@ img {
 	top:-26px;
 	padding: 4px;
 	font-size: 220%;
+	display: none;
 }
 
 .nextLightBox, .prevLightBox {

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -1,3 +1,7 @@
+/* vertical centering via display flex causes issues on smaller screens on narrower displays
+require the animation on the box, not the contents
+*/
+
 * {
 	-webkit-box-sizing: border-box;
 	-moz-box-sizing: border-box;
@@ -32,7 +36,7 @@ img {
     background: #000;
     background: rgba(0,0,0,0.8);
 	opacity: 0;
-	text-align: center;
+	/* text-align: center; */
 	z-index: -1;
 	display: flex; /* consider adding webkit prefix if you're feeling kind */
 	align-items: center;
@@ -50,8 +54,8 @@ img {
     margin-top: 5%;
     margin-bottom: 5%;
     position: relative;
-	text-align: center;
 	display: inline-block;
+	max-width: 80%;
 }
 
 .rbox_lightBox {

--- a/jquery-rbox.css
+++ b/jquery-rbox.css
@@ -71,6 +71,14 @@ img {
 	text-decoration: none;
 }
 
+.nextLightBox:after {
+	content: "\25b6";
+}
+
+.prevLightBox:after {
+	content: "\25c0";
+}
+
 .closeLightBox {
 	position: absolute;
 	right: -14px;

--- a/jquery-rbox.js
+++ b/jquery-rbox.js
@@ -107,6 +107,7 @@
                     'namespace': namespace,
                     'loading': 'Loading...',
                     'closeonoverlay': true,
+                    'closebtn': true,
                     'beforeopen': function(opts) { return opts; }, //called before open
                     'onopen': function() { $.noop(); }, //called onopen
                     'onclose': function() { $.noop(); }, //called onclose
@@ -226,13 +227,17 @@
         $('.rbox_lightBoxBlock').addClass('rbox_' + opts.type);
         $('.rbox_overlay').addClass('rbox_show');
         //$('.rbox_overlay').show(opts.fade, function(){
-    
+        
         if (opts.closeonoverlay) {
             $('.rbox_overlay').bind("click", function() {
                 $('.closeLightBox').click();
             });
         }
 
+
+        if(opts.closebtn) {
+            $('.closeLightBox').css({'display': 'block'});
+        }
 
         $('.rbox_lightBoxContent').empty().append(content).addClass('rbox_show_content');
         if (opts.caption) {

--- a/jquery-rbox.js
+++ b/jquery-rbox.js
@@ -106,6 +106,7 @@
                     'fitvid': false, //whether to use fitvid plugin (must be included)
                     'namespace': namespace,
                     'loading': 'Loading...',
+                    'closeonoverlay': true,
                     'beforeopen': function(opts) { return opts; }, //called before open
                     'onopen': function() { $.noop(); }, //called onopen
                     'onclose': function() { $.noop(); }, //called onclose
@@ -225,15 +226,20 @@
         $('.rbox_lightBoxBlock').addClass('rbox_' + opts.type);
         $('.rbox_overlay').addClass('rbox_show');
         //$('.rbox_overlay').show(opts.fade, function(){
-        $('.rbox_overlay').bind("click", function() {
-            $('.closeLightBox').click();
-        });
+    
+        if (opts.closeonoverlay) {
+            $('.rbox_overlay').bind("click", function() {
+                $('.closeLightBox').click();
+            });
+        }
+
 
         $('.rbox_lightBoxContent').empty().append(content).addClass('rbox_show_content');
         if (opts.caption) {
             var $caption = $('<div />').addClass('rbox_caption').html(opts.caption);
             $('.rbox_lightBoxContent').append($caption);
         }
+
         if (opts.fitvid) {
             $('.rbox_lightBoxContent').find('iframe').wrap('<div class="rbox_fitvid" />');
             $('.rbox_fitvid').fitVids();    

--- a/jquery-rbox.js
+++ b/jquery-rbox.js
@@ -75,7 +75,7 @@
                 namespace = options.namespace || "rbox",
                 
                 optionTypes = {
-                    'strings': ['series', 'type', 'image', 'iframe', 'html', 'ajax', 'video', 'videoposter', 'caption', 'loading', 'inline'],
+                    'strings': ['series', 'type', 'image', 'iframe', 'html', 'ajax', 'video', 'videoposter', 'caption', 'loading', 'inline', 'bgcustom'],
                     'integers': ['width', 'height', 'fade'],
                     'floats': [],
                     'arrays':  [],
@@ -108,6 +108,7 @@
                     'loading': 'Loading...',
                     'closeonoverlay': true,
                     'closebtn': true,
+                    'bgcustom': 'rgba(0, 0, 0, 0.8)', // color value for overlay
                     'beforeopen': function(opts) { return opts; }, //called before open
                     'onopen': function() { $.noop(); }, //called onopen
                     'onclose': function() { $.noop(); }, //called onclose
@@ -234,6 +235,9 @@
             });
         }
 
+        if(opts.bgcustom) {
+            $('.rbox_overlay').css({'backgroundColor': opts.bgcustom});
+        }
 
         if(!opts.closebtn) {
             $('.closeLightBox').hide();

--- a/jquery-rbox.js
+++ b/jquery-rbox.js
@@ -240,10 +240,10 @@
         }
 
         if(!opts.closebtn) {
-            $('.closeLightBox').hide();
+            $('.closeLightBox').css('display', 'none');
         }
         else {
-            $('.closeLightBox').show();            
+            $('.closeLightBox').css('display', '');            
         }
 
         $('.rbox_lightBoxContent').empty().append(content).addClass('rbox_show_content');

--- a/jquery-rbox.js
+++ b/jquery-rbox.js
@@ -5,9 +5,9 @@
         var $lightboxBlock = $('<div />').addClass('rbox_lightBoxBlock').appendTo($overlay);
         var $lightbox = $('<div />').addClass('rbox_lightBox').appendTo($lightboxBlock);
         var $content = $('<div />').addClass('rbox_lightBoxContent').appendTo($lightbox);
-        var $close = $('<a />').attr('href', '').addClass('closeLightBox').text('X').appendTo($lightbox);
-        var $next = $('<a />').attr('href', '').addClass('nextLightBox').appendTo($lightbox);
-        var $prev = $('<a />').attr('href', '').addClass('prevLightBox').appendTo($lightbox);
+        var $close = $('<a />').attr('href', '').addClass('closeLightBox').html("&#x274c;").appendTo($lightbox);
+        var $next = $('<a />').attr('href', '').addClass('nextLightBox').html("&#x25b6;").appendTo($lightbox);
+        var $prev = $('<a />').attr('href', '').addClass('prevLightBox').html("&#x25c0;").appendTo($lightbox);
         $('body').append($overlay);
     }
 
@@ -75,7 +75,7 @@
                 namespace = options.namespace || "rbox",
                 
                 optionTypes = {
-                    'strings': ['series', 'type', 'image', 'iframe', 'html', 'ajax', 'video', 'videoposter', 'caption', 'loading', 'inline', 'bgcustom'],
+                    'strings': ['series', 'type', 'image', 'iframe', 'html', 'ajax', 'video', 'videoposter', 'caption', 'loading', 'inline', 'bgcustom', 'closebtnclass'],
                     'integers': ['width', 'height', 'fade'],
                     'floats': [],
                     'arrays':  [],
@@ -108,6 +108,9 @@
                     'loading': 'Loading...',
                     'closeonoverlay': true,
                     'closebtn': true,
+                    //'closebtnmarkup' : '',
+                    'navmarkup' : ['&#x274c;', '&#x25c0;', '&#x25b6;'], /*close, prev, next */
+                    'closebtnclass' : '',
                     'bgcustom': 'rgba(0, 0, 0, 0.8)', // color value for overlay
                     'beforeopen': function(opts) { return opts; }, //called before open
                     'onopen': function() { $.noop(); }, //called onopen
@@ -244,6 +247,20 @@
         }
         else {
             $('.closeLightBox').css('display', '');            
+        }
+
+        // if(opts.closebtnmarkup) {
+        //     $('.closeLightBox').html(opts.closebtnmarkup);
+        // }
+
+        if(opts.navmarkup) {
+            $('.closeLightBox').html(opts.navmarkup[0]);
+            $('.prevLightBox').html(opts.navmarkup[1]);
+            $('.nextLightBox').html(opts.navmarkup[2]);
+        }
+
+        if(opts.closebtnclass) {
+            $('.closeLightBox').addClass(opts.closebtnclass);
         }
 
         $('.rbox_lightBoxContent').empty().append(content).addClass('rbox_show_content');

--- a/jquery-rbox.js
+++ b/jquery-rbox.js
@@ -235,8 +235,11 @@
         }
 
 
-        if(opts.closebtn) {
-            $('.closeLightBox').css({'display': 'block'});
+        if(!opts.closebtn) {
+            $('.closeLightBox').hide();
+        }
+        else {
+            $('.closeLightBox').show();            
         }
 
         $('.rbox_lightBoxContent').empty().append(content).addClass('rbox_show_content');

--- a/jquery-rbox.js
+++ b/jquery-rbox.js
@@ -6,8 +6,8 @@
         var $lightbox = $('<div />').addClass('rbox_lightBox').appendTo($lightboxBlock);
         var $content = $('<div />').addClass('rbox_lightBoxContent').appendTo($lightbox);
         var $close = $('<a />').attr('href', '').addClass('closeLightBox').text('X').appendTo($lightbox);
-        var $next = $('<a />').attr('href', '').addClass('nextLightBox').html('&#8594;').appendTo($lightbox);
-        var $prev = $('<a />').attr('href', '').addClass('prevLightBox').html('&#8592;').appendTo($lightbox);
+        var $next = $('<a />').attr('href', '').addClass('nextLightBox').appendTo($lightbox);
+        var $prev = $('<a />').attr('href', '').addClass('prevLightBox').appendTo($lightbox);
         $('body').append($overlay);
     }
 


### PR DESCRIPTION
Updates

- Added option to prevent closing rbox on clicking overlay via closeonoverlay option
- Added option to hide close button via closebtn option
- Added option to customize background overlay per instance of lightbox: bgcustom (added to strings array in optionTypes as well.
- Added option to add custom close buttons: closebtncustom (added to strings array in optionTypes as well.
- Improved overall documentation
- Replaced generated CSS for next and previous with HTML unicode. Replaced text of close button with HTML unicode.
- Added array option for custom markup for next, previous and close icons. Trying to figure sensible defaults while customizing, NEEDS WORK
